### PR TITLE
Add retry logic with exponential backoff for feed fetching

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -77,6 +77,26 @@ function httpsGet(url, additionalHeaders = {}) {
   });
 }
 
+// Retry wrapper for httpsGet with exponential backoff
+async function httpsGetWithRetry(url, retries = 3, delay = 2000) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await httpsGet(url);
+    } catch (error) {
+      const isLastAttempt = attempt === retries;
+      const isServerError = error.message.includes('HTTP 5');
+
+      if (isServerError && !isLastAttempt) {
+        console.log(`⚠️  Feed returned server error (attempt ${attempt}/${retries}), retrying in ${delay}ms...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay *= 2; // Exponential backoff
+      } else {
+        throw error;
+      }
+    }
+  }
+}
+
 // Function to post message to Slack with retry logic
 async function postToSlack(webhookUrl, message, retries = 3, delay = 2000) {
   const postData = JSON.stringify(message);
@@ -426,8 +446,8 @@ async function main() {
 
     console.log(`📡 Fetching album feed from: ${ALBUM_FEED_URL}`);
 
-    // Fetch the JSON feed
-    const feed = await httpsGet(ALBUM_FEED_URL);
+    // Fetch the JSON feed with retry logic for transient server errors
+    const feed = await httpsGetWithRetry(ALBUM_FEED_URL);
 
     if (!feed.items || feed.items.length === 0) {
       throw new Error("No albums found in feed");
@@ -567,4 +587,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, formatAlbumMessage, getPacificDateString, getTopWikipediaUrl };
+module.exports = { main, formatAlbumMessage, getPacificDateString, getTopWikipediaUrl, httpsGetWithRetry };


### PR DESCRIPTION
## Summary
This PR adds resilience to feed fetching by implementing a retry mechanism with exponential backoff for transient server errors. The main feed fetch operation now automatically retries on HTTP 5xx errors instead of failing immediately.

## Key Changes
- **New `httpsGetWithRetry()` function**: Wraps the existing `httpsGet()` call with retry logic that:
  - Attempts up to 3 times by default (configurable)
  - Detects HTTP 5xx server errors and retries only for those
  - Implements exponential backoff, doubling the delay between attempts (starting at 2000ms)
  - Logs retry attempts with attempt count and delay information
  - Fails immediately on non-server errors (e.g., 4xx, network errors)

- **Updated feed fetching**: The album feed fetch in `main()` now uses `httpsGetWithRetry()` instead of direct `httpsGet()` call

- **Export addition**: Added `httpsGetWithRetry` to module exports for testability

## Implementation Details
- The retry logic only applies to HTTP 5xx errors (detected via error message), allowing the function to fail fast on client errors or network issues
- Exponential backoff prevents overwhelming a temporarily unavailable server
- Console logging provides visibility into retry attempts for debugging

https://claude.ai/code/session_01EzH1veUvjfihH8gwynQ7GM